### PR TITLE
Clarify average docstring bessel parameter

### DIFF
--- a/dependencies/backtrader/mathsupport.py
+++ b/dependencies/backtrader/mathsupport.py
@@ -29,8 +29,8 @@ def average(x, bessel=False):
     Args:
       x: iterable with len
 
-      oneless: (default ``False``) reduces the length of the array for the
-                division.
+      bessel: (default ``False``) if ``True`` divides by ``N - 1`` instead of
+                ``N``.
 
     Returns:
       A float with the average of the elements of x


### PR DESCRIPTION
## Summary
- clarify the `average` docstring to describe the `bessel` parameter and its impact on the divisor

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fd10e7b2a0832ab5f8641b176fe6e0