### PR TITLE
Fix typo in CommInfo comment

### DIFF
--- a/dependencies/backtrader/comminfo.py
+++ b/dependencies/backtrader/comminfo.py
@@ -136,7 +136,7 @@ class CommInfoBase(with_metaclass(MetaParams)):
         self._stocklike = self.p.stocklike
         self._commtype = self.p.commtype
 
-        # The intial block checks for the behavior of the original
+        # The initial block checks for the behavior of the original
         # CommissionInfo in which the commission scheme (perc/fixed) was
         # determined by parameter "margin" evaluating to False/True
         # If the parameter "commtype" is None, this behavior is emulated


### PR DESCRIPTION
## Summary
- correct a typo in the comment describing the initial CommissionInfo behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd10e82a04832ab31ec603b9cc1bc3