### PR TITLE
Add unit tests for ccxt data utilities

### DIFF
--- a/dependencies/backtrader/utils/tests/conftest.py
+++ b/dependencies/backtrader/utils/tests/conftest.py
@@ -1,0 +1,149 @@
+import sys
+import types
+
+# Some optional dependencies are not available in the test environment. Stub them so that
+# importing backtrader packages during test collection does not fail.
+if "matplotlib" not in sys.modules:
+    matplotlib_stub = types.ModuleType("matplotlib")
+    matplotlib_stub.__dict__.setdefault("__path__", [])
+
+    def _noop(*_args, **_kwargs):
+        return None
+
+    matplotlib_stub.use = _noop
+    sys.modules["matplotlib"] = matplotlib_stub
+
+    pyplot_stub = types.ModuleType("pyplot")
+    pyplot_stub.plot = _noop
+    pyplot_stub.show = _noop
+    sys.modules["matplotlib.pyplot"] = pyplot_stub
+
+if "rich" not in sys.modules:
+    rich_stub = types.ModuleType("rich")
+    progress_stub = types.ModuleType("progress")
+
+    class _DummyProgress:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def add_task(self, *args, **kwargs):
+            return 0
+
+        def advance(self, *args, **kwargs):
+            return None
+
+    progress_stub.Progress = _DummyProgress
+    progress_stub.SpinnerColumn = object
+    progress_stub.TextColumn = object
+    progress_stub.BarColumn = object
+    progress_stub.TaskProgressColumn = object
+    progress_stub.TimeRemainingColumn = object
+
+    rich_stub.progress = progress_stub
+    console_stub = types.ModuleType("console")
+
+    class _DummyConsole:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def status(self, *args, **kwargs):
+            return _DummyProgress()
+
+        def print(self, *args, **kwargs):
+            return None
+
+    console_stub.Console = _DummyConsole
+    rich_stub.console = console_stub
+    sys.modules["rich"] = rich_stub
+    sys.modules["rich.progress"] = progress_stub
+    sys.modules["rich.console"] = console_stub
+
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+
+    class _DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {}
+
+    def _request(*_args, **_kwargs):
+        return _DummyResponse()
+
+    requests_stub.get = _request
+    requests_stub.post = _request
+    requests_stub.put = _request
+    requests_stub.delete = _request
+    sys.modules["requests"] = requests_stub
+
+if "telethon" not in sys.modules:
+    telethon_stub = types.ModuleType("telethon")
+
+    class _DummyTelegramClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self):
+            return None
+
+        def is_connected(self):
+            return True
+
+        async def is_user_authorized(self):
+            return True
+
+        async def get_entity(self, *args, **kwargs):
+            return None
+
+        async def send_message(self, *args, **kwargs):
+            return None
+
+        async def disconnect(self):
+            return None
+
+    telethon_stub.TelegramClient = _DummyTelegramClient
+    sys.modules["telethon"] = telethon_stub
+
+if "joblib" not in sys.modules:
+    joblib_stub = types.ModuleType("joblib")
+
+    def _joblib_noop(*_args, **_kwargs):
+        return None
+
+    joblib_stub.load = _joblib_noop
+    joblib_stub.dump = _joblib_noop
+    sys.modules["joblib"] = joblib_stub
+
+if "pandas" not in sys.modules:
+    pandas_stub = types.ModuleType("pandas")
+
+    class _DummyDataFrame:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    pandas_stub.DataFrame = _DummyDataFrame
+    pandas_stub.Series = _DummyDataFrame
+    sys.modules["pandas"] = pandas_stub
+
+if "fast_mssql" not in sys.modules:
+    sys.modules["fast_mssql"] = types.ModuleType("fast_mssql")
+
+if "web3" not in sys.modules:
+    web3_stub = types.ModuleType("web3")
+
+    class _DummyWeb3:
+        class HTTPProvider:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    web3_stub.Web3 = _DummyWeb3
+    sys.modules["web3"] = web3_stub

--- a/dependencies/backtrader/utils/tests/test_ccxt_data.py
+++ b/dependencies/backtrader/utils/tests/test_ccxt_data.py
@@ -1,0 +1,115 @@
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import types
+
+import pytest
+
+try:
+    import polars  # noqa: F401 - we only check availability for optional dependency
+except ModuleNotFoundError:  # pragma: no cover - optional dependency during testing
+    POLARS_AVAILABLE = False
+    sys.modules.setdefault("polars", types.SimpleNamespace())
+else:
+    POLARS_AVAILABLE = True
+
+try:
+    import ccxt  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - optional dependency during testing
+    sys.modules.setdefault("ccxt", types.SimpleNamespace(exchanges=[]))
+
+# Ensure the backtrader package is importable when running tests from the repository root
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+DEPENDENCIES_PATH = PROJECT_ROOT / "dependencies"
+if str(DEPENDENCIES_PATH) not in sys.path:
+    sys.path.insert(0, str(DEPENDENCIES_PATH))
+
+MODULE_PATH = DEPENDENCIES_PATH / "backtrader" / "utils" / "ccxt_data.py"
+spec = importlib.util.spec_from_file_location("ccxt_data", MODULE_PATH)
+ccxt_data = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(ccxt_data)
+
+get_crypto_data = ccxt_data.get_crypto_data
+unix_time_millis = ccxt_data.unix_time_millis
+
+
+@pytest.mark.parametrize(
+    "date_str,time_resolution,expected",
+    [
+        ("2024-01-01", "1d", int(datetime(2024, 1, 1).timestamp() * 1000)),
+        ("2024-01-01 15:30:00", "1h", int(datetime(2024, 1, 1, 15, 30).timestamp() * 1000)),
+    ],
+)
+def test_unix_time_millis_converts_dates(date_str, time_resolution, expected):
+    assert unix_time_millis(date_str, time_resolution) == expected
+
+
+def test_unix_time_millis_adds_midnight_for_intraday():
+    # Intraday resolutions expect a timestamp with time information. When only a date is provided
+    # the helper should assume midnight to keep the behaviour deterministic.
+    expected_midnight = int(datetime(2024, 1, 1).timestamp() * 1000)
+    assert unix_time_millis("2024-01-01", "1h") == expected_midnight
+
+
+class MockExchange:
+    last_instance = None
+
+    def __init__(self, *_args, **_kwargs):
+        self.calls = 0
+        MockExchange.last_instance = self
+
+    def fetch_ohlcv(self, asset, timeframe, since=None):
+        self.calls += 1
+
+        if self.calls == 1:
+            return []
+
+        if self.calls == 2:
+            return [
+                [int(datetime(2023, 1, 2).timestamp() * 1000), 1, 2, 3, 4, 5],
+                [int(datetime(2023, 1, 3).timestamp() * 1000), 2, 3, 4, 5, 6],
+                [int(datetime(2023, 1, 4).timestamp() * 1000), 3, 4, 5, 6, 7],
+            ]
+
+        return []
+
+
+@pytest.fixture
+def mock_ccxt(monkeypatch):
+    import ccxt
+
+    monkeypatch.setattr(ccxt, "exchanges", ["mockexchange"], raising=False)
+    monkeypatch.setattr(ccxt, "mockexchange", MockExchange, raising=False)
+
+    return ccxt
+
+
+@pytest.mark.skipif(not POLARS_AVAILABLE, reason="polars is required for DataFrame processing")
+def test_get_crypto_data_skips_empty_batches_and_trims_end_date(mock_ccxt):
+    import polars as pl_local
+
+    start_date = "2023-01-01"
+    end_date = "2023-01-03"
+
+    df = get_crypto_data("BTC/USDT", start_date, end_date, "1d", "mockexchange")
+
+    assert isinstance(df, pl_local.DataFrame)
+    assert df.height == 2
+
+    expected_dates = [
+        datetime(2023, 1, 2),
+        datetime(2023, 1, 3),
+    ]
+    assert df.select(pl_local.col("dt")).to_series().to_list() == expected_dates
+
+    assert df["start_date"].to_list() == [start_date, start_date]
+    assert df["end_date"].to_list() == [end_date, end_date]
+    assert df["symbol"].to_list() == ["BTC/USDT", "BTC/USDT"]
+
+    # Ensure the mocked exchange was called until data was available and then stopped
+    assert MockExchange.last_instance is not None
+    assert MockExchange.last_instance.calls == 2
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath =
+    dependencies


### PR DESCRIPTION
## Summary
- add pytest configuration so the dependencies package is importable during test runs
- create ccxt data utility tests covering unix_time_millis conversions and mocking ccxt data responses
- provide lightweight stubs for optional heavy dependencies to allow test collection without external packages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd10e8cf08832a8fbad3372714dae9