### PR TITLE
Add BaseStrategy showcase and order tracker tests

### DIFF
--- a/Examples/BaseStrategy_Showcase.py
+++ b/Examples/BaseStrategy_Showcase.py
@@ -1,0 +1,182 @@
+"""Comprehensive BaseStrategy example
+=====================================
+
+This script demonstrates how to build a production-ready strategy on top of
+``BaseStrategy``.  It walks through:
+
+* Wiring the strategy into a :class:`backtrader.cerebro.Cerebro` engine for
+  backtesting.
+* Re-using the same strategy with CCXT-based exchanges (e.g. Binance, MEXC).
+* Preparing the configuration for Web3 compatible exchanges such as
+  PancakeSwap via the built-in PancakeSwap order bridge.
+* Tapping into the order tracking utilities that persist active positions.
+
+The example is intentionally verbose and heavily documented so that new users
+can use it as a template for their own ideas.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import backtrader as bt
+
+from dependencies.backtrader.strategies.base import BaseStrategy, OrderTracker
+
+
+class FullyDocumentedStrategy(BaseStrategy):
+    """Example strategy showcasing BaseStrategy features.
+
+    The strategy trades a simple moving-average cross over the ``close`` prices
+    of the first data feed, but the surrounding infrastructure demonstrates how
+    to work with ``BaseStrategy``'s order tracking, position sizing, and
+    exchange helpers.
+
+    Highlights
+    ----------
+    * Uses ``self.calculate_position_size`` to respect exchange minimum order
+      sizes.
+    * Demonstrates how to persist orders with :class:`OrderTracker`.
+    * Triggers alerts via the BaseStrategy hooks when ``enable_alerts`` is set.
+    * Works both for standard CCXT exchanges and Web3 integrations.
+    """
+
+    params = dict(
+        short_period=10,
+        long_period=30,
+        percent_sizer=0.05,
+        take_profit=1.0,
+        backtest=True,
+        exchange="binance",
+        asset="BTCUSDT",
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.short_ma = bt.indicators.SimpleMovingAverage(self.data.close, period=self.p.short_period)
+        self.long_ma = bt.indicators.SimpleMovingAverage(self.data.close, period=self.p.long_period)
+
+    def next(self):
+        if not self.position and self.short_ma > self.long_ma and self.buy_or_short_condition() is False:
+            self.calculate_position_size()
+            size = self.amount or 0.001
+            order = self.buy(size=size)
+            self.entry_prices.append(self.data.close[0])
+            self.sizes.append(size)
+            self.calc_averages()
+            OrderTracker(self.data.close[0], size, self.p.take_profit, symbol=self.p.asset, backtest=self.p.backtest)
+            self.send_alert(f"Opened long position via BaseStrategy at {self.data.close[0]:.2f}")
+            return order
+
+        if self.position and self.short_ma < self.long_ma and self.sell_or_cover_condition() is False:
+            self.sell(size=self.position.size)
+            self.send_alert(f"Closed long position via BaseStrategy at {self.data.close[0]:.2f}")
+
+
+@dataclass
+class StrategyConfig:
+    """Configuration container for the showcase example."""
+
+    data: Iterable[bt.feeds.PandasData]
+    cash: float = 100_000.0
+    exchange: str = "binance"
+    asset: str = "BTCUSDT"
+    enable_alerts: bool = False
+    alert_channel: Optional[str] = None
+    pancakeswap_coin: Optional[str] = None
+    pancakeswap_collateral: Optional[str] = None
+
+
+def run_backtest(config: StrategyConfig) -> bt.Cerebro:
+    """Run a standard backtest using ``FullyDocumentedStrategy``.
+
+    Parameters
+    ----------
+    config:
+        High level configuration describing the data feeds and exchange flavour.
+    """
+
+    cerebro = bt.Cerebro()
+    for data_feed in config.data:
+        cerebro.adddata(data_feed)
+
+    cerebro.broker.setcash(config.cash)
+
+    cerebro.addstrategy(
+        FullyDocumentedStrategy,
+        exchange=config.exchange,
+        asset=config.asset,
+        enable_alerts=config.enable_alerts,
+        alert_channel=config.alert_channel,
+        coin=config.pancakeswap_coin,
+        collateral=config.pancakeswap_collateral,
+        backtest=True,
+    )
+
+    cerebro.addobserver(bt.observers.BuySell)
+    cerebro.addanalyzer(bt.analyzers.TradeAnalyzer, _name="trades")
+    return cerebro
+
+
+def example_ccxt_usage(data_feed: bt.feeds.PandasData):
+    """Illustrate how to configure the strategy for a CCXT exchange."""
+
+    config = StrategyConfig(data=[data_feed], exchange="binance", asset="BTCUSDT")
+    cerebro = run_backtest(config)
+    results = cerebro.run()
+    analyzer = results[0].analyzers.trades.get_analysis()
+    print("Trade analysis:", analyzer)
+
+
+def example_web3_usage(data_feed: bt.feeds.PandasData):
+    """Illustrate how to configure the strategy for PancakeSwap/Web3 trading."""
+
+    config = StrategyConfig(
+        data=[data_feed],
+        exchange="pancakeswap",
+        asset="CAKEBUSD",
+        pancakeswap_coin="CAKE",
+        pancakeswap_collateral="BUSD",
+        enable_alerts=True,
+    )
+    cerebro = run_backtest(config)
+    cerebro.run()
+    print("Web3 example completed. Orders will be routed through the PancakeSwap bridge.")
+
+
+def load_csv_data(path: Path) -> bt.feeds.PandasData:
+    """Load OHLCV data from CSV using pandas."""
+
+    import pandas as pd
+
+    dataframe = pd.read_csv(path, parse_dates=True, index_col="datetime")
+    return bt.feeds.PandasData(dataname=dataframe)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the BaseStrategy showcase example")
+    parser.add_argument("--csv", type=Path, help="Path to a CSV file containing OHLCV data", required=False)
+    parser.add_argument("--web3", action="store_true", help="Demonstrate PancakeSwap/Web3 setup")
+    parser.add_argument("--alerts", action="store_true", help="Enable alert integrations")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.csv is None:
+        raise SystemExit("Please provide a CSV file via --csv to run the example.")
+
+    data_feed = load_csv_data(args.csv)
+
+    if args.web3:
+        example_web3_usage(data_feed)
+    else:
+        example_ccxt_usage(data_feed)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    main()

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ BTQuant is a comprehensive algorithmic trading framework designed for **backtest
 
 💬 **[Join Our HFT Community](https://discord.gg/Y7uBxmRg3Z)** - Connect with quantitative traders using **real tick data**
 
+### New Learning Resources
+
+- Explore the fully documented **BaseStrategy showcase** located at
+  `Examples/BaseStrategy_Showcase.py` for an end-to-end walkthrough covering
+  backtesting, CCXT connectivity, and Web3/PancakeSwap routing.
+- Check out the new automated tests in `tests/test_order_tracker.py` to learn
+  how order tracking is validated and to use them as a template for additional
+  coverage.
+
 ---
 
 *BTQuant: Where **custom infrastructure** meets **institutional performance***

--- a/tests/test_order_tracker.py
+++ b/tests/test_order_tracker.py
@@ -1,0 +1,151 @@
+import importlib.util
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _AutoMockModule(ModuleType):
+    """Module stub that lazily returns :class:`MagicMock` attributes."""
+
+    def __getattr__(self, item):  # pragma: no cover - simple passthrough
+        mock = MagicMock(name=f"{self.__name__}.{item}")
+        setattr(self, item, mock)
+        return mock
+
+
+def _load_base_module():
+    """Load the BaseStrategy module with a lightweight ``backtrader`` stub."""
+
+    if "backtrader" not in sys.modules:
+        bt_stub = ModuleType("backtrader")
+        bt_stub.Strategy = object
+        bt_stub.Analyzer = object
+        bt_stub.observers = SimpleNamespace(BuySell=type("BuySell", (object,), {}))
+        bt_stub.analyzers = SimpleNamespace(TradeAnalyzer=object)
+        bt_stub.indicators = MagicMock()
+        bt_stub.feeds = MagicMock()
+        bt_stub.sizers = MagicMock()
+        bt_stub.brokers = MagicMock()
+        bt_stub.stores = MagicMock()
+        bt_stub.WriterBase = object
+        sys.modules["backtrader"] = bt_stub
+
+    if "numpy" not in sys.modules:
+        numpy_stub = _AutoMockModule("numpy")
+        numpy_stub.bool_ = bool
+        sys.modules["numpy"] = numpy_stub
+
+    module_name = "btquant_base_strategy_for_tests"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    module_path = Path(__file__).resolve().parents[1] / "dependencies/backtrader/strategies/base.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+OrderTracker = _load_base_module().OrderTracker
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(tmp_path, monkeypatch):
+    original_cwd = os.getcwd()
+    monkeypatch.chdir(tmp_path)
+    try:
+        yield
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_close_order_updates_state_for_buy():
+    tracker = OrderTracker(entry_price=100.0, size=2.0, take_profit_pct=5, symbol="BTCUSDT", backtest=True)
+
+    tracker.close_order(exit_price=110.0)
+
+    assert tracker.closed is True
+    assert tracker.exit_price == pytest.approx(110.0)
+    assert tracker.profit_pct == pytest.approx(10.0)
+    assert tracker.exit_timestamp is not None
+
+
+def test_close_order_updates_state_for_sell():
+    tracker = OrderTracker(entry_price=100.0, size=1.0, take_profit_pct=2, symbol="BTCUSDT", order_type="SELL", backtest=True)
+
+    tracker.close_order(exit_price=90.0)
+
+    assert tracker.closed is True
+    # For SELL orders profits are calculated inversely
+    assert tracker.profit_pct == pytest.approx(((100.0 / 90.0) - 1) * 100)
+
+
+def test_load_active_orders_from_csv_filters_and_parses(tmp_path):
+    csv_path = tmp_path / "order_tracker.csv"
+    rows = [
+        {
+            "order_id": "1",
+            "symbol": "BTCUSDT",
+            "order_type": "BUY",
+            "entry_price": "30000",
+            "size": "0.01",
+            "take_profit_price": "31500",
+            "timestamp": datetime.now().isoformat(),
+            "closed": "False",
+            "exit_price": "",
+            "exit_timestamp": "",
+            "profit_pct": ""
+        },
+        {
+            "order_id": "2",
+            "symbol": "ETHUSDT",
+            "order_type": "BUY",
+            "entry_price": "2000",
+            "size": "0.5",
+            "take_profit_price": "2100",
+            "timestamp": (datetime.now() - timedelta(days=1)).isoformat(),
+            "closed": "True",
+            "exit_price": "2100",
+            "exit_timestamp": datetime.now().isoformat(),
+            "profit_pct": "5.0"
+        },
+    ]
+
+    header = [
+        "order_id",
+        "symbol",
+        "order_type",
+        "entry_price",
+        "size",
+        "take_profit_price",
+        "timestamp",
+        "closed",
+        "exit_price",
+        "exit_timestamp",
+        "profit_pct",
+    ]
+
+    with csv_path.open("w", encoding="utf-8") as csv_file:
+        csv_file.write(",".join(header) + "\n")
+        for row in rows:
+            csv_file.write(",".join(str(row[col]) for col in header) + "\n")
+
+    loaded_orders = OrderTracker.load_active_orders_from_csv(symbol="BTCUSDT")
+
+    assert len(loaded_orders) == 1
+    order = loaded_orders[0]
+    assert order.symbol == "BTCUSDT"
+    assert order.size == pytest.approx(0.01)
+    assert order.entry_price == pytest.approx(30000.0)
+    assert order.closed is False
+    assert order.profit_pct is None
+
+
+def test_load_active_orders_from_csv_without_file():
+    assert OrderTracker.load_active_orders_from_csv(symbol="BTCUSDT") == []


### PR DESCRIPTION
## Summary
- add a fully documented BaseStrategy showcase example covering backtesting, CCXT, and Web3 usage
- extend the README with links to the new example and test resources
- create unit tests for OrderTracker behaviors with lightweight stubs for external dependencies

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68fd1e10b744832aa67ad9feef4e15ab