### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     # Run daily at 2 AM UTC to catch regressions
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -150,6 +153,8 @@ jobs:
 
   performance-benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/itsXactlY/BTQuant/security/code-scanning/6](https://github.com/itsXactlY/BTQuant/security/code-scanning/6)

In general, fix this by defining a `permissions` block in the workflow that restricts `GITHUB_TOKEN` to the minimum needed, and then override it per job where additional scopes (like `contents: write`) are truly required. This both documents intended access and prevents accidental elevation if repo/organization defaults change.

For this specific file, the safest, least-disruptive approach is:

- Add a top-level `permissions` block (before `jobs:`) setting `contents: read`. This will apply to all jobs by default.
- Override permissions for `performance-benchmark`, which explicitly pushes benchmark results via `github-token` with `auto-push: true`. That job needs `contents: write`, so add a `permissions:` block under `performance-benchmark` with `contents: write`.
- Override permissions for `deploy`, which publishes packages to external registries but does not appear to modify the repository itself. It only needs to read the code, so leave it using the inherited `contents: read` default (no per-job override needed).
- The other jobs (`test`, `security-scan`, `nightly-regression` etc. as implied) only read the repository and upload artifacts to GitHub’s artifact storage, which works with `contents: read`, so they can rely on the root `permissions` block.

All changes are in `.github/workflows/ci.yml`. No new imports or external libraries are required; we only adjust YAML keys/values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
